### PR TITLE
Support for png images

### DIFF
--- a/src/dialog.js
+++ b/src/dialog.js
@@ -114,7 +114,7 @@ prompt.dup = (file, options) =>
 open.images = (options) => open({
   filters: [{
     name: t('dialog.filter.images'),
-    extensions: ['jpg', 'jpeg']
+    extensions: ['jpg', 'jpeg', 'png']
   }],
   properties: ['openFile', 'multiSelections'],
   ...options

--- a/src/image.js
+++ b/src/image.js
@@ -167,9 +167,8 @@ function resize(image, size) {
 }
 
 function isValidImage(file) {
-  return file.type === 'image/jpeg'
+  return ['image/jpeg', 'image/png'].includes(file.type)
 }
-
 
 function NI(src) {
   return new Promise((resolve) => {
@@ -184,6 +183,10 @@ function magic(b) {
 
   if (b[0] === 0xFF && b[1] === 0xD8 && b[2] === 0xFF) {
     return 'image/jpeg'
+  }
+  if (b.slice(0, 8).compare(
+    Buffer.from([137, 80, 78, 71, 13, 10, 26, 10])) === 0) {
+    return 'image/png'
   }
 }
 

--- a/src/image.js
+++ b/src/image.js
@@ -127,8 +127,11 @@ class Image {
 
           const buffer = Buffer.concat(chunks)
 
+          // do not extract exif from png
+          let exifFn = (this.mimetype !== 'image/png') ? exif : () => ({})
+
           Promise
-            .all([exif(buffer), NI(buffer), stat(this.path)])
+            .all([exifFn(buffer), NI(buffer), stat(this.path)])
 
             .then(([data, original, file]) =>
               assign(this, original.getSize(), { exif: data, original, file }))


### PR DESCRIPTION
As these are natively supported by electron's `nativeImage`, it was just a matter of extending the list and signature/header checking.

I've tried to do tiff as well, but it obviously failed.

I would prefer to postpone creating further abstractions until there is actually a need for them - e.g. when we're adding tiff support. 