### PR TITLE
Export: lists, tags, notes, selections

### DIFF
--- a/res/vocab/tropy.n3
+++ b/res/vocab/tropy.n3
@@ -26,15 +26,21 @@ tropy:Item a rdfs:Class ;
   rdfs:isDefinedBy <https://tropy.org/v1/tropy#> ;
   rdfs:comment "A Tropy item contains metadata and photos."@en .
 
-tropy:Photo a rdfs:Class ;
+tropy:Image a rdfs:Class ;
   rdfs:subClassOf rdfs:Resource ;
-  rdfs:label "Photo"@en , "Photo"@fr , "Foto"@de ;
+  rdfs:label "Image"@en ;
+  rdfs:isDefinedBy <https://tropy.org/v1/tropy#> ;
+  rdfs:comment "An image (photo or selection)."@en .
+
+tropy:Photo a rdfs:Class ;
+  rdfs:subClassOf tropy:Image ;
+  rdfs:label "Photo"@en ;
   rdfs:isDefinedBy <https://tropy.org/v1/tropy#> ;
   rdfs:comment "A photo."@en .
 
 tropy:Selection a rdfs:Class ;
-  rdfs:subClassOf rdfs:Resource ;
-  rdfs:label "Selection"@en "Sélection"@fr , "Ausschnitt"@de ;
+  rdfs:subClassOf rdfs:Image ;
+  rdfs:label "Selection"@en ;
   rdfs:isDefinedBy <https://tropy.org/v1/tropy#> ;
   rdfs:comment "A selection within a photo."@en .
 
@@ -55,6 +61,18 @@ tropy:Field a rdfs:Class ;
   rdfs:label "Template Field"@en ;
   rdfs:isDefinedBy <https://tropy.org/v1/tropy#> ;
   rdfs:comment "A Tropy template field."@en .
+
+tropy:List a rdfs:Class ;
+  rdfs:subClassOf rdfs:Resource ;
+  rdfs:label "List"@en ;
+  rdfs:isDefinedBy <https://tropy.org/v1/tropy#> ;
+  rdfs:comment "A list of Tropy items."@en .
+
+tropy:Tag a rdfs:Class ;
+  rdfs:subClassOf rdfs:Resource ;
+  rdfs:label "Tag"@en ;
+  rdfs:isDefinedBy <https://tropy.org/v1/tropy#> ;
+  rdfs:comment "A tag or label."@en .
 
 
 # Data Types
@@ -93,6 +111,29 @@ tropy:selection a rdf:Property ;
   rdfs:domain tropy:Photo ;
   rdfs:range tropy:Selection ;
 	rdfs:comment "A Tropy photo selection."@en .
+
+tropy:list a rdf:Property ;
+	rdfs:label "List"@en ;
+	rdfs:isDefinedBy <https://tropy.org/v1/tropy#> ;
+  rdfs:domain tropy:Item ;
+  rdfs:range tropy:List ;
+	rdfs:comment "A list containing the item."@en .
+
+tropy:tag a rdf:Property ;
+	rdfs:label "Tag"@en ;
+	rdfs:isDefinedBy <https://tropy.org/v1/tropy#> ;
+  rdfs:domain tropy:Item ;
+  rdfs:range tropy:Tag ;
+	rdfs:comment "A tag applied to the item."@en .
+
+
+tropy:note a rdf:Property ;
+	rdfs:label "Note"@en ;
+	rdfs:isDefinedBy <https://tropy.org/v1/tropy#> ;
+  rdfs:domain tropy:Item , tropy:Photo , tropy:Selection ;
+  rdfs:range tropy:Note ;
+	rdfs:comment "A rich-text note."@en .
+
 
 tropy:box a rdf:Property ;
 	rdfs:label "Box"@en , "Carton"@fr , "Box"@de ;

--- a/src/commands/item.js
+++ b/src/commands/item.js
@@ -460,7 +460,8 @@ class Export extends Command {
             template,
             items: Object.values(itms).filter(i => i.template === t),
             metadata: state.metadata,
-            photos: state.photos
+            photos: state.photos,
+            lists: state.lists
           })
         }
         return [results, state.ontology.props]

--- a/src/commands/item.js
+++ b/src/commands/item.js
@@ -462,7 +462,8 @@ class Export extends Command {
             metadata: state.metadata,
             photos: state.photos,
             lists: state.lists,
-            tags: state.tags
+            tags: state.tags,
+            notes: state.notes
           })
         }
         return [results, state.ontology.props]

--- a/src/commands/item.js
+++ b/src/commands/item.js
@@ -461,7 +461,8 @@ class Export extends Command {
             items: Object.values(itms).filter(i => i.template === t),
             metadata: state.metadata,
             photos: state.photos,
-            lists: state.lists
+            lists: state.lists,
+            tags: state.tags
           })
         }
         return [results, state.ontology.props]

--- a/src/commands/item.js
+++ b/src/commands/item.js
@@ -439,7 +439,7 @@ class Export extends Command {
 
       if (!path) return
 
-      const [resources, props] = yield select(state => {
+      const [templateItems, ...resources] = yield select(state => {
         const itms = pick(state.items, ids)
         const templateIDs = Object.values(itms).map(itm => itm.template)
         const templates = pick(state.ontology.template, templateIDs)
@@ -459,17 +459,14 @@ class Export extends Command {
           results.push({
             template,
             items: Object.values(itms).filter(i => i.template === t),
-            metadata: state.metadata,
-            photos: state.photos,
-            lists: state.lists,
-            tags: state.tags,
-            notes: state.notes
           })
         }
-        return [results, state.ontology.props]
+        const needed = [
+          'metadata', 'photos', 'lists', 'tags', 'notes', 'selections']
+        return [results, state.ontology.props, ...pluck(state, needed)]
       })
 
-      const results = yield call(groupedByTemplate, resources, props)
+      const results = yield call(groupedByTemplate, templateItems, resources)
 
       const data = JSON.stringify(results, null, 2)
 

--- a/src/commands/item.js
+++ b/src/commands/item.js
@@ -459,11 +459,6 @@ class Export extends Command {
           results.push({
             template,
             items: Object.values(itms).filter(i => i.template === t),
-            metadata: state.metadata,
-            photos: state.photos,
-            lists: state.lists,
-            tags: state.tags,
-            notes: state.notes
           })
         }
         const needed = [

--- a/src/commands/item.js
+++ b/src/commands/item.js
@@ -462,7 +462,8 @@ class Export extends Command {
             metadata: state.metadata,
             photos: state.photos,
             lists: state.lists,
-            tags: state.tags
+            tags: state.tags,
+            notes: state.notes
           })
         }
         const needed = [

--- a/src/commands/item.js
+++ b/src/commands/item.js
@@ -459,6 +459,9 @@ class Export extends Command {
           results.push({
             template,
             items: Object.values(itms).filter(i => i.template === t),
+            metadata: state.metadata,
+            photos: state.photos,
+            lists: state.lists
           })
         }
         const needed = [

--- a/src/commands/item.js
+++ b/src/commands/item.js
@@ -461,7 +461,8 @@ class Export extends Command {
             items: Object.values(itms).filter(i => i.template === t),
             metadata: state.metadata,
             photos: state.photos,
-            lists: state.lists
+            lists: state.lists,
+            tags: state.tags
           })
         }
         const needed = [

--- a/src/constants/type.js
+++ b/src/constants/type.js
@@ -5,5 +5,8 @@ module.exports = {
   TEXT: 'http://www.w3.org/2001/XMLSchema#string',
   ITEM: 'https://tropy.org/v1/tropy#Item',
   PHOTO: 'https://tropy.org/v1/tropy#Photo',
-  SELECTION: 'https://tropy.org/v1/tropy#Selection'
+  SELECTION: 'https://tropy.org/v1/tropy#Selection',
+
+  // These identify the exported JSON-LD entities
+  LIST: 'https://tropy.org/v1/tropy#List'
 }

--- a/src/constants/type.js
+++ b/src/constants/type.js
@@ -8,5 +8,6 @@ module.exports = {
   SELECTION: 'https://tropy.org/v1/tropy#Selection',
 
   // These identify the exported JSON-LD entities
-  LIST: 'https://tropy.org/v1/tropy#List'
+  LIST: 'https://tropy.org/v1/tropy#List',
+  NOTE: 'https://tropy.org/v1/tropy#Note'
 }

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -3,7 +3,8 @@
 const { promises: jsonld } = require('jsonld')
 
 const { pick, pluck } = require('../common/util')
-const { ITEM, PHOTO, SELECTION, NOTE } = require('../constants/type')
+const { ITEM, PHOTO, SELECTION } = require('../constants/type')
+const makeNote = require('./note')
 
 const TR = 'https://tropy.org/v1/tropy#'
 
@@ -82,15 +83,6 @@ function addInfo(target, ids, key, state, fn = x => x.name) {
     }
   }
   return target
-}
-
-function makeNote(note) {
-  return {
-    '@type': NOTE,
-    'text': note.text,
-    'doc': JSON.stringify(note.state.doc),
-    'language': note.language
-  }
 }
 
 function addSelections(template, photo, ids, resources) {

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -122,6 +122,14 @@ function renderItem(item, template, resources) {
   result = addInfo(result, item.lists, 'list', lists)
   result = addInfo(result, item.tags, 'tag', tags)
 
+  // add item tags info
+  if (item.tags && item.tags.length) {
+    result.tag = values(pick(tags, item.tags)).map(t => t.name)
+    if (result.tag.length === 1) {
+      result.tag = result.tag[0]
+    }
+  }
+
   // add item metadata
   result = newProperties(metadata[item.id], result, false, props, template)
 

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -140,7 +140,7 @@ function renderItem(item, template, resources) {
     let photo = {
       '@type': PHOTO,
       'path': p.path,
-      'selection': [],
+      'selection': []
     }
 
     photo = newProperties(metadata[p.id], photo, false, props, template)

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -64,9 +64,17 @@ function makeContext(items, photos, metadata, template, props) {
   return result
 }
 
-function renderItem(item, photos, metadata, template, props) {
+function renderItem(item, photos, metadata, template, props, lists) {
   // the item starts with a photo property, it may not be overwritten
   let result = { '@type': ITEM, 'photo': [] }
+
+  // add item list info
+  if (item.lists && item.lists.length) {
+    result.list = values(pick(lists, item.lists)).map(l => l.name)
+    if (result.list.length === 1) {
+      result.list = result.list[0]
+    }
+  }
 
   // add item metadata
   result = newProperties(metadata[item.id], result, false, props, template)
@@ -110,7 +118,7 @@ function renderItem(item, photos, metadata, template, props) {
   return result
 }
 
-function makeDocument(items, photos, metadata, template, props) {
+function makeDocument(items, photos, metadata, template, props, lists) {
   const result = {
     'template': template.id,
     '@graph': []
@@ -125,9 +133,10 @@ function makeDocument(items, photos, metadata, template, props) {
 async function groupedByTemplate(resources, props = {}) {
   const results = []
   for (const resource of resources) {
-    const { items, metadata, template, photos } = resource
+    const { items, metadata, template, photos, lists } = resource
     const context = makeContext(items, photos, metadata, template, props)
-    const document = makeDocument(items, photos, metadata, template, props)
+    const document = makeDocument(
+      items, photos, metadata, template, props, lists)
     document['@context'] = context
     results.push(await jsonld.compact(document, context))
   }

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -124,7 +124,7 @@ function makeDocument(items, photos, metadata, template, props, lists) {
     '@graph': []
   }
   for (const item of items) {
-    const rendered = renderItem(item, photos, metadata, template, props)
+    const rendered = renderItem(item, photos, metadata, template, props, lists)
     result['@graph'].push(rendered)
   }
   return result

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -19,24 +19,29 @@ const PROP = {
   HEIGHT: `${IFFF}height`,
 }
 
+const EXPORT_MEDIA = [
+  'angle',
+  'brightness',
+  'contrast',
+  'height',
+  'hue',
+  'mirror',
+  'negative',
+  'saturation',
+  'width',
+]
 const EXPORT_PROPERTIES = {
   SELECTION: [
-    'angle',
-    'height',
-    'mirror',
-    'width',
     'x',
     'y',
+    ...EXPORT_MEDIA
   ],
   PHOTO: [
-    'angle',
     'checksum',
-    'height',
     'mimetype',
-    'mirror',
     'orientation',
     'size',
-    'width',
+    ...EXPORT_MEDIA
   ]
 }
 

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -152,7 +152,6 @@ function renderItem(item, template, resources) {
   return result
 }
 
-
 function makeDocument(template, items, resources) {
   const result = {
     'template': template.id,

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -140,7 +140,7 @@ function renderItem(item, template, resources) {
     let photo = {
       '@type': PHOTO,
       'path': p.path,
-      'selection': []
+      'selection': [],
     }
 
     photo = newProperties(metadata[p.id], photo, false, props, template)

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -7,13 +7,37 @@ const { ITEM, PHOTO, SELECTION } = require('../constants/type')
 const makeNote = require('./note')
 
 const TR = 'https://tropy.org/v1/tropy#'
+const IFFF = 'http://iiif.io/api/image/2#'
 
 const PROP = {
   TEMPLATE: `${TR}template`,
   ITEM: `${TR}item`,
   PHOTO: `${TR}photo`,
   SELECTION: `${TR}selection`,
-  NOTE: `${TR}note`
+  NOTE: `${TR}note`,
+  WIDTH: `${IFFF}width`,
+  HEIGHT: `${IFFF}height`,
+}
+
+const EXPORT_PROPERTIES = {
+  SELECTION: [
+    'angle',
+    'height',
+    'mirror',
+    'width',
+    'x',
+    'y',
+  ],
+  PHOTO: [
+    'angle',
+    'checksum',
+    'height',
+    'mimetype',
+    'mirror',
+    'orientation',
+    'size',
+    'width',
+  ]
 }
 
 const { newProperties } = require('./utils')
@@ -41,7 +65,9 @@ function makeContext(template, items, resources) {
           '@id': PROP.SELECTION,
           '@container': '@list',
           '@context': {}
-        }
+        },
+        width: PROP.WIDTH,
+        height: PROP.HEIGHT
       }
     }
   }
@@ -86,7 +112,6 @@ function addInfo(target, ids, key, state, fn = x => x.name) {
 }
 
 function addSelections(template, photo, ids, resources) {
-  const selProps = ['x', 'y', 'width', 'height', 'angle', 'mirror', 'template']
   const [props, metadata,,,, notes, selections] = resources
 
   if (ids) {
@@ -94,7 +119,7 @@ function addSelections(template, photo, ids, resources) {
       let selection = { '@type': SELECTION }
       const original = selections[sID]
       // add selection properties
-      Object.assign(selection, pick(original, selProps))
+      Object.assign(selection, pick(original, EXPORT_PROPERTIES.SELECTION))
 
       // add selection notes
       selection = addInfo(selection, original.notes, 'note', notes, makeNote)
@@ -140,7 +165,8 @@ function renderItem(item, template, resources) {
     let photo = {
       '@type': PHOTO,
       'path': p.path,
-      'selection': []
+      'selection': [],
+      ...pick(p, EXPORT_PROPERTIES.PHOTO)
     }
 
     photo = newProperties(metadata[p.id], photo, false, props, template)

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -147,14 +147,6 @@ function renderItem(item, template, resources) {
   result = addInfo(result, item.lists, 'list', lists)
   result = addInfo(result, item.tags, 'tag', tags)
 
-  // add item tags info
-  if (item.tags && item.tags.length) {
-    result.tag = values(pick(tags, item.tags)).map(t => t.name)
-    if (result.tag.length === 1) {
-      result.tag = result.tag[0]
-    }
-  }
-
   // add item metadata
   result = newProperties(metadata[item.id], result, false, props, template)
 

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -64,7 +64,7 @@ function makeContext(items, photos, metadata, template, props) {
   return result
 }
 
-function renderItem(item, photos, metadata, template, props, lists) {
+function renderItem(item, photos, metadata, template, props, lists, tags) {
   // the item starts with a photo property, it may not be overwritten
   let result = { '@type': ITEM, 'photo': [] }
 
@@ -73,6 +73,14 @@ function renderItem(item, photos, metadata, template, props, lists) {
     result.list = values(pick(lists, item.lists)).map(l => l.name)
     if (result.list.length === 1) {
       result.list = result.list[0]
+    }
+  }
+
+  // add item tags info
+  if (item.tags && item.tags.length) {
+    result.tag = values(pick(tags, item.tags)).map(t => t.name)
+    if (result.tag.length === 1) {
+      result.tag = result.tag[0]
     }
   }
 
@@ -118,13 +126,13 @@ function renderItem(item, photos, metadata, template, props, lists) {
   return result
 }
 
-function makeDocument(items, photos, metadata, template, props, lists) {
+function makeDocument(items, photos, metadata, template, props, lists, tags) {
   const result = {
     'template': template.id,
     '@graph': []
   }
   for (const item of items) {
-    const rendered = renderItem(item, photos, metadata, template, props, lists)
+    const rendered = renderItem(item, photos, metadata, template, props, lists, tags)
     result['@graph'].push(rendered)
   }
   return result
@@ -133,10 +141,10 @@ function makeDocument(items, photos, metadata, template, props, lists) {
 async function groupedByTemplate(resources, props = {}) {
   const results = []
   for (const resource of resources) {
-    const { items, metadata, template, photos, lists } = resource
+    const { items, metadata, template, photos, lists, tags } = resource
     const context = makeContext(items, photos, metadata, template, props)
     const document = makeDocument(
-      items, photos, metadata, template, props, lists)
+      items, photos, metadata, template, props, lists, tags)
     document['@context'] = context
     results.push(await jsonld.compact(document, context))
   }

--- a/src/export/note.js
+++ b/src/export/note.js
@@ -1,0 +1,23 @@
+'use strict'
+
+const { NOTE } = require('../constants/type')
+
+const { DOMSerializer } = require('prosemirror-model')
+const { schema } = require('../components/editor/schema')
+
+const serializer = DOMSerializer.fromSchema(schema)
+
+function toHTML(doc) {
+  const node = schema.nodeFromJSON(doc)
+  const docFragment = serializer.serializeFragment(node)
+  return Array.from(docFragment.children).map(x => x.outerHTML).join('')
+}
+
+module.exports = function (note) {
+  return {
+    '@type': NOTE,
+    'text': note.text,
+    'html': toHTML(note.state.doc),
+    'language': note.language
+  }
+}

--- a/src/export/note.js
+++ b/src/export/note.js
@@ -4,13 +4,19 @@ const { NOTE } = require('../constants/type')
 
 const { DOMSerializer } = require('prosemirror-model')
 const { schema } = require('../components/editor/schema')
+const { warn } = require('../common/log')
 
 const serializer = DOMSerializer.fromSchema(schema)
 
 function toHTML(doc) {
-  const node = schema.nodeFromJSON(doc)
-  const docFragment = serializer.serializeFragment(node)
-  return Array.from(docFragment.children).map(x => x.outerHTML).join('')
+  try {
+    const node = schema.nodeFromJSON(doc)
+    const docFragment = serializer.serializeFragment(node)
+    return Array.from(docFragment.children).map(x => x.outerHTML).join('')
+  } catch (error) {
+    warn('Could not convert note to html', { error, doc })
+    return ''
+  }
 }
 
 module.exports = function (note) {

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -2,12 +2,12 @@
 
 describe('export', () => {
   const { groupedByTemplate } = __require('export')
-  const { template, items, metadata, props, photos, lists, tags } =
+  const { template, items, metadata, props, photos, lists, tags, notes } =
         require('../fixtures/export')
   const { keys } = Object
 
   const resources = [
-    { template, items, metadata, photos, lists, tags }
+    { template, items, metadata, photos, lists, tags, notes }
   ]
 
   const ld = groupedByTemplate(resources, props)
@@ -87,7 +87,7 @@ describe('export', () => {
     })
   })
 
-  describe('item has auxiliary property', () => {
+  describe('item has auxiliary property:', () => {
     it('list', async () => {
       const data = (await ld)[0]['@graph']
       expect(data[0]).to.not.have.property('list')
@@ -98,6 +98,15 @@ describe('export', () => {
       const data = (await ld)[0]['@graph']
       expect(data[0]).to.not.have.property('tag')
       expect(data[1]['tag']).to.eql('mytag')
+    })
+  })
+
+  describe('photo has auxiliary property', () => {
+    it('note', async () => {
+      const item1 = (await ld)[0]['@graph'][0]
+      expect(item1.photo[0]).to.not.have.property('note')
+      expect(item1.photo[1]['note']['text']).to.eql('photo note')
+      expect(item1.photo[1]['note']['doc']).to.eql('{"foo":"bar"}')
     })
   })
 })

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -2,15 +2,15 @@
 
 describe('export', () => {
   const { groupedByTemplate } = __require('export')
-  const { template, items, metadata, props, photos, lists, tags, notes } =
-        require('../fixtures/export')
+  const f = require('../fixtures/export')
+
   const { keys } = Object
 
   const resources = [
-    { template, items, metadata, photos, lists, tags, notes }
-  ]
+    f.props, f.metadata, f.photos, f.lists, f.tags, f.notes, f.selections]
 
-  const ld = groupedByTemplate(resources, props)
+  const ld = groupedByTemplate(
+    [{ template: f.template, items: f.items }], resources)
 
   it('has item.template', async () => {
     const data = (await ld)[0]

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -81,13 +81,11 @@ describe('export', () => {
 
   it('has photo->selection metadata', async () => {
     const data = (await ld)[0]['@graph'][0]['photo'][1]['selection']
-    expect(data).to.eql({
-      '@type': 'Selection',
-      'selectProp': 'selection property'
-    })
+    expect(data).to.have.property('@type', 'Selection')
+    expect(data).to.have.property('selectProp', 'selection property')
   })
 
-  describe('item has auxiliary property:', () => {
+  describe('item has', () => {
     it('list', async () => {
       const data = (await ld)[0]['@graph']
       expect(data[0]).to.not.have.property('list')
@@ -101,12 +99,26 @@ describe('export', () => {
     })
   })
 
-  describe('photo has auxiliary property', () => {
+  describe('photo has', () => {
     it('note', async () => {
       const item1 = (await ld)[0]['@graph'][0]
       expect(item1.photo[0]).to.not.have.property('note')
       expect(item1.photo[1]['note']['text']).to.eql('photo note')
       expect(item1.photo[1]['note']['doc']).to.eql('{"foo":"bar"}')
+    })
+  })
+
+  describe('selection has', async () => {
+    const s = (await ld)[0]['@graph'][0]['photo'][1]['selection']
+    it('coordinates', () => {
+      expect(s).to.have.property('x', 10)
+      expect(s).to.have.property('y', 20)
+      expect(s).to.have.property('width', 30)
+      expect(s).to.have.property('height', 40)
+    })
+    it('note', () => {
+      expect(s['note']['text']).to.eql('selection note')
+      expect(s['note']['doc']).to.be.undefined
     })
   })
 })

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -104,7 +104,7 @@ describe('export', () => {
       const item1 = (await ld)[0]['@graph'][0]
       expect(item1.photo[0]).to.not.have.property('note')
       expect(item1.photo[1]['note']['text']).to.eql('photo note')
-      expect(item1.photo[1]['note']['doc']).to.eql('{"foo":"bar"}')
+      expect(item1.photo[1]['note']['html']).to.eql('<p>photo note</p>')
     })
   })
 

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -3,7 +3,7 @@
 describe('export', () => {
   const { groupedByTemplate } = __require('export')
   const { template, items, metadata, props, photos, lists } =
-        require('./helpers')
+        require('../fixtures/export')
   const { keys } = Object
 
   const resources = [
@@ -89,9 +89,9 @@ describe('export', () => {
 
   describe('item has auxiliary property', () => {
     it('list', async () => {
-      const data = (await ld)[0]['item']
+      const data = (await ld)[0]['@graph']
       expect(data[0]).to.not.have.property('list')
-      expect(data[1]['list']).to.eql(['list1'])
+      expect(data[1]['list']).to.eql('list1')
     })
   })
 })

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -2,12 +2,12 @@
 
 describe('export', () => {
   const { groupedByTemplate } = __require('export')
-  const { template, items, metadata, props, photos, lists } =
+  const { template, items, metadata, props, photos, lists, tags } =
         require('../fixtures/export')
   const { keys } = Object
 
   const resources = [
-    { template, items, metadata, photos, lists }
+    { template, items, metadata, photos, lists, tags }
   ]
 
   const ld = groupedByTemplate(resources, props)
@@ -92,6 +92,12 @@ describe('export', () => {
       const data = (await ld)[0]['@graph']
       expect(data[0]).to.not.have.property('list')
       expect(data[1]['list']).to.eql('list1')
+    })
+
+    it('tag', async () => {
+      const data = (await ld)[0]['@graph']
+      expect(data[0]).to.not.have.property('tag')
+      expect(data[1]['tag']).to.eql('mytag')
     })
   })
 })

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -2,13 +2,12 @@
 
 describe('export', () => {
   const { groupedByTemplate } = __require('export')
-  const {
-    template, items, metadata, props, photos
-  } = require('../fixtures/export')
+  const { template, items, metadata, props, photos, lists } =
+        require('./helpers')
   const { keys } = Object
 
   const resources = [
-    { template, items, metadata, photos }
+    { template, items, metadata, photos, lists }
   ]
 
   const ld = groupedByTemplate(resources, props)
@@ -85,6 +84,14 @@ describe('export', () => {
     expect(data).to.eql({
       '@type': 'Selection',
       'selectProp': 'selection property'
+    })
+  })
+
+  describe('item has auxiliary property', () => {
+    it('list', async () => {
+      const data = (await ld)[0]['item']
+      expect(data[0]).to.not.have.property('list')
+      expect(data[1]['list']).to.eql(['list1'])
     })
   })
 })

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -60,12 +60,11 @@ describe('export', () => {
   it('has photo metadata', async () => {
     const data = (await ld)[0]['@graph'][0]
     expect(keys(data.photo).length).to.eql(2)
-    expect(data.photo[0]).to.eql({
-      '@type': 'Photo',
-      'path': '/path',
-      'helloWorld': 'photo property',
-      'nonTemplateProperty': 'custom property'
-    })
+    const photo = data.photo[0]
+    expect(photo).to.have.property('@type', 'Photo')
+    expect(photo).to.have.property('path', '/path')
+    expect(photo).to.have.property('helloWorld', 'photo property')
+    expect(photo).to.have.property('nonTemplateProperty', 'custom property')
   })
 
   it('has photo->selection @context', async () => {
@@ -106,6 +105,15 @@ describe('export', () => {
       expect(item1.photo[1]['note']['text']).to.eql('photo note')
       expect(item1.photo[1]['note']['html']).to.eql('<p>photo note</p>')
     })
+
+    it('width, etc.', async () => {
+      const item1 = (await ld)[0]['@graph'][0]
+      expect(item1.photo[1]).to.not.have.property('width')
+      const photo = item1.photo[0]
+      expect(photo).to.have.property('width', 30)
+      expect(photo).to.have.property('height', 40)
+    })
+
   })
 
   describe('selection has', async () => {

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -149,7 +149,7 @@ describe('export', () => {
       const item1 = (await ld)[0]['@graph'][0]
       expect(item1.photo[0]).to.not.have.property('note')
       expect(item1.photo[1]['note']['text']).to.eql('photo note')
-      expect(item1.photo[1]['note']['doc']).to.eql('{"foo":"bar"}')
+      expect(item1.photo[1]['note']['html']).to.eql('<p>photo note</p>')
     })
   })
 

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -121,7 +121,7 @@ describe('export', () => {
     })
   })
 
-  describe('item has auxiliary property', () => {
+  describe('item has auxiliary property:', () => {
     it('list', async () => {
       const data = (await ld)[0]['@graph']
       expect(data[0]).to.not.have.property('list')
@@ -132,6 +132,15 @@ describe('export', () => {
       const data = (await ld)[0]['@graph']
       expect(data[0]).to.not.have.property('tag')
       expect(data[1]['tag']).to.eql('mytag')
+    })
+  })
+
+  describe('photo has auxiliary property', () => {
+    it('note', async () => {
+      const item1 = (await ld)[0]['@graph'][0]
+      expect(item1.photo[0]).to.not.have.property('note')
+      expect(item1.photo[1]['note']['text']).to.eql('photo note')
+      expect(item1.photo[1]['note']['doc']).to.eql('{"foo":"bar"}')
     })
   })
 })

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -2,6 +2,7 @@
 
 describe('export', () => {
   const { groupedByTemplate } = __require('export')
+
   const f = require('../fixtures/export')
 
   const { keys } = Object
@@ -119,6 +120,14 @@ describe('export', () => {
     it('note', () => {
       expect(s['note']['text']).to.eql('selection note')
       expect(s['note']['doc']).to.be.undefined
+    })
+  })
+
+  describe('item has auxiliary property', () => {
+    it('list', async () => {
+      const data = (await ld)[0]['item']
+      expect(data[0]).to.not.have.property('list')
+      expect(data[1]['list']).to.eql(['list1'])
     })
   })
 })

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -122,7 +122,7 @@ describe('export', () => {
     })
   })
 
-  describe('item has auxiliary property:', () => {
+  describe('item has', () => {
     it('list', async () => {
       const data = (await ld)[0]['@graph']
       expect(data[0]).to.not.have.property('list')
@@ -136,12 +136,26 @@ describe('export', () => {
     })
   })
 
-  describe('photo has auxiliary property', () => {
+  describe('photo has', () => {
     it('note', async () => {
       const item1 = (await ld)[0]['@graph'][0]
       expect(item1.photo[0]).to.not.have.property('note')
       expect(item1.photo[1]['note']['text']).to.eql('photo note')
       expect(item1.photo[1]['note']['doc']).to.eql('{"foo":"bar"}')
+    })
+  })
+
+  describe('selection has', async () => {
+    const s = (await ld)[0]['@graph'][0]['photo'][1]['selection']
+    it('coordinates', () => {
+      expect(s).to.have.property('x', 10)
+      expect(s).to.have.property('y', 20)
+      expect(s).to.have.property('width', 30)
+      expect(s).to.have.property('height', 40)
+    })
+    it('note', () => {
+      expect(s['note']['text']).to.eql('selection note')
+      expect(s['note']['doc']).to.be.undefined
     })
   })
 })

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -3,6 +3,7 @@
 describe('export', () => {
   const { groupedByTemplate } = __require('export')
   const f = require('../fixtures/export')
+
   const { keys } = Object
 
   const resources = [

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -127,5 +127,11 @@ describe('export', () => {
       expect(data[0]).to.not.have.property('list')
       expect(data[1]['list']).to.eql('list1')
     })
+
+    it('tag', async () => {
+      const data = (await ld)[0]['@graph']
+      expect(data[0]).to.not.have.property('tag')
+      expect(data[1]['tag']).to.eql('mytag')
+    })
   })
 })

--- a/test/export/export_test.js
+++ b/test/export/export_test.js
@@ -2,9 +2,7 @@
 
 describe('export', () => {
   const { groupedByTemplate } = __require('export')
-
   const f = require('../fixtures/export')
-
   const { keys } = Object
 
   const resources = [
@@ -125,9 +123,9 @@ describe('export', () => {
 
   describe('item has auxiliary property', () => {
     it('list', async () => {
-      const data = (await ld)[0]['item']
+      const data = (await ld)[0]['@graph']
       expect(data[0]).to.not.have.property('list')
-      expect(data[1]['list']).to.eql(['list1'])
+      expect(data[1]['list']).to.eql('list1')
     })
   })
 })

--- a/test/fixtures/export.js
+++ b/test/fixtures/export.js
@@ -15,7 +15,7 @@ const template = {
 
 const items = [
   { id: 1, template: 'https://tropy.org/v1/tropy#test-template', photos: [11, 12] },
-  { id: 2, template: 'https://tropy.org/v1/tropy#test-template', lists: [1] }
+  { id: 2, template: 'https://tropy.org/v1/tropy#test-template', lists: [1], tags: [1] }
 ]
 
 const metadata = {
@@ -95,6 +95,10 @@ const lists = {
   1: { name: 'list1' }
 }
 
+const tags = {
+  1: { name: 'mytag' }
+}
+
 module.exports = {
   template,
   items,
@@ -104,5 +108,6 @@ module.exports = {
   vocab,
   classes,
   datatypes,
-  lists
+  lists,
+  tags
 }

--- a/test/fixtures/export.js
+++ b/test/fixtures/export.js
@@ -14,7 +14,8 @@ const template = {
 }
 
 const items = [
-  { id: 1, template: 'https://tropy.org/v1/tropy#test-template', photos: [11, 12] }
+  { id: 1, template: 'https://tropy.org/v1/tropy#test-template', photos: [11, 12] },
+  { id: 2, template: 'https://tropy.org/v1/tropy#test-template', lists: [1] }
 ]
 
 const metadata = {
@@ -90,6 +91,10 @@ const datatypes = {
   }
 }
 
+const lists = {
+  1: { name: 'list1' }
+}
+
 module.exports = {
   template,
   items,
@@ -98,5 +103,6 @@ module.exports = {
   photos,
   vocab,
   classes,
-  datatypes
+  datatypes,
+  lists
 }

--- a/test/fixtures/export.js
+++ b/test/fixtures/export.js
@@ -109,7 +109,21 @@ const tags = {
 }
 
 const notes = {
-  1: { text: 'photo note', state: { doc: { foo: 'bar' } } },
+  1: {
+    text: 'photo note',
+    state: {
+      doc: {
+        type: 'doc',
+        content: [{
+          type: 'paragraph',
+          content: [{
+            type: 'text',
+            text: 'photo note'
+          }]
+        }]
+      }
+    }
+  },
   2: { text: 'selection note', state: {} }
 }
 

--- a/test/fixtures/export.js
+++ b/test/fixtures/export.js
@@ -14,8 +14,17 @@ const template = {
 }
 
 const items = [
-  { id: 1, template: 'https://tropy.org/v1/tropy#test-template', photos: [11, 12] },
-  { id: 2, template: 'https://tropy.org/v1/tropy#test-template', lists: [1], tags: [1] }
+  {
+    id: 1,
+    template: 'https://tropy.org/v1/tropy#test-template',
+    photos: [11, 12]
+  },
+  {
+    id: 2,
+    template: 'https://tropy.org/v1/tropy#test-template',
+    lists: [1],
+    tags: [1]
+  }
 ]
 
 const metadata = {
@@ -61,7 +70,7 @@ const props = {
 
 const photos = {
   11: { id: 11, path: '/path' },
-  12: { path: '/another', selections: [21] }
+  12: { id: 12, path: '/another', selections: [21], notes: [1] }
 }
 
 const vocab = {
@@ -99,6 +108,11 @@ const tags = {
   1: { name: 'mytag' }
 }
 
+const notes = {
+  1: { text: 'photo note', state: { doc: { foo: 'bar' } } },
+  2: { text: 'selection note' }
+}
+
 module.exports = {
   template,
   items,
@@ -109,5 +123,6 @@ module.exports = {
   classes,
   datatypes,
   lists,
-  tags
+  tags,
+  notes
 }

--- a/test/fixtures/export.js
+++ b/test/fixtures/export.js
@@ -23,7 +23,8 @@ const items = [
     id: 2,
     template: 'https://tropy.org/v1/tropy#test-template',
     lists: [1],
-    tags: [1]
+    tags: [1],
+    photos: []
   }
 ]
 

--- a/test/fixtures/export.js
+++ b/test/fixtures/export.js
@@ -69,7 +69,7 @@ const props = {
 }
 
 const photos = {
-  11: { id: 11, path: '/path' },
+  11: { id: 11, path: '/path', width: 30, height: 40 },
   12: { id: 12, path: '/another', selections: [21], notes: [1] }
 }
 

--- a/test/fixtures/export.js
+++ b/test/fixtures/export.js
@@ -110,7 +110,11 @@ const tags = {
 
 const notes = {
   1: { text: 'photo note', state: { doc: { foo: 'bar' } } },
-  2: { text: 'selection note' }
+  2: { text: 'selection note', state: {} }
+}
+
+const selections = {
+  21: { x: 10, y: 20, width: 30, height: 40, notes: [2] }
 }
 
 module.exports = {
@@ -124,5 +128,6 @@ module.exports = {
   datatypes,
   lists,
   tags,
-  notes
+  notes,
+  selections
 }


### PR DESCRIPTION
Lists and tags are exported by name.

For notes, both unformatted text as well as the formatted document are being exported. This allows for both easy processing as well as full rich-text restoring on import. The rich-text part is json-stringified - this may be slightly controversial, but has the advantage of not creating excessive structure in the jsonld.

Notes are exported for photos and selections. There seems to be no way to attach a note to an item directly, just these two subjects.

I'm not quite sure in which case to use `https://tropy.org/v1/tropy#note` as the `@type` and when to use `https://tropy.org/v1/tropy#Note` (capitalized). The later should be a rdf-class? The lowercase ones are now used in `@context` while the uppercase are used in the body of the document. Need some guidance here.