### PR TITLE
Notepad links: minor fixes

### DIFF
--- a/src/components/editor/selections.js
+++ b/src/components/editor/selections.js
@@ -1,40 +1,40 @@
 'use strict'
 
+const hasMark = (pos, index, markType) =>
+      markType.isInSet(pos.parent.child(index).marks)
+
+const calculate = (pos, markType) => {
+  let startIndex = pos.index()
+  let endIndex = pos.indexAfter()
+
+  if (startIndex === pos.parent.childCount) {
+    startIndex--
+  }
+  while (startIndex > 0 && hasMark(pos, startIndex, markType)) {
+    startIndex--
+  }
+  while (endIndex < pos.parent.childCount && hasMark(pos, endIndex, markType)) {
+    endIndex++
+  }
+
+  let startPos = pos.start()
+  let endPos = startPos
+
+  for (let i = 0; i < endIndex; i++) {
+    let size = pos.parent.child(i).nodeSize
+    if (i <= startIndex) startPos += size
+    endPos += size
+  }
+
+  return { from: startPos, to: endPos }
+}
+
 const markExtend = (selection, markType) => {
   if (!selection) return
 
-  const hasMark = (pos, index) =>
-    markType.isInSet(pos.parent.child(index).marks)
-
-  const calculate = (pos) => {
-    let startIndex = pos.index()
-    let endIndex = pos.indexAfter()
-
-    if (startIndex === pos.parent.childCount) {
-      startIndex--
-    }
-    while (startIndex > 0 && hasMark(pos, startIndex)) {
-      startIndex--
-    }
-    while (endIndex < pos.parent.childCount && hasMark(pos, endIndex)) {
-      endIndex++
-    }
-
-    let startPos = pos.start()
-    let endPos = startPos
-
-    for (let i = 0; i < endIndex; i++) {
-      let size = pos.parent.child(i).nodeSize
-      if (i <= startIndex) startPos += size
-      endPos += size
-    }
-
-    return { from: startPos, to: endPos }
-  }
-
   return {
-    from: calculate(selection.$from).from,
-    to: calculate(selection.$to).to
+    from: calculate(selection.$from, markType).from,
+    to: calculate(selection.$to, markType).to
   }
 }
 

--- a/test/fixtures/editor.js
+++ b/test/fixtures/editor.js
@@ -1,6 +1,6 @@
 'use strict'
 
-const { EditorState, TextSelection } = require('prosemirror-state')
+const { EditorState } = require('prosemirror-state')
 const { doc, p } = require('prosemirror-test-builder')
 const { schema } = __require('components/editor/schema')
 
@@ -21,12 +21,9 @@ state = state.apply(
     offset + url.length,
     schema.marks.link.create({ href: url })))
 
-// select 'www'
-state = state.apply(
-  state.tr.setSelection(
-    TextSelection.create(state.doc, offset + 7, offset + 10)))
-
 module.exports = {
   state,
-  url
+  url,
+  offset,
+  www: { from: offset + 7, to: offset + 10 } // helper for selection the url
 }


### PR DESCRIPTION
This fixes the following:
* _if you select text left to a link and up into the link, mark extend will select the region outside of the link_
* _if you select a link from its left edge (does not matter if you select the whole link, more than the link, or part of the link), mark extend seems to select only that left edge (i.e. the link is not removed)_
* if more than one link is selected, both are removed (this seems more consistent to me)

It's still not perfect, but the remaining issues seem not important (e.g. too much text to the right is selected). That's what happens when you copy someone's code from the forums and don't fully understand it.