### PR TITLE
Export Photo order

### DIFF
--- a/src/export/export.js
+++ b/src/export/export.js
@@ -72,7 +72,9 @@ function renderItem(item, photos, metadata, template, props) {
   result = newProperties(metadata[item.id], result, false, props, template)
 
   // add photo metadata
-  result.photo = values(pick(photos, item.photos)).map(p => {
+  result.photo = item.photos.map(photoID => {
+    const p = photos[photoID]
+
     let photo = {
       '@type': PHOTO,
       'path': p.path,


### PR DESCRIPTION
> stakats [Jan 10, 4:54 PM] 
> somewhere along the way image order is getting lost
> either in the JSON-LD or the omeka importer

The order was being lost in the jsonld export. This patch fixes it.