### PR TITLE
Export items w/ missing template

### DIFF
--- a/src/commands/item.js
+++ b/src/commands/item.js
@@ -22,10 +22,10 @@ const { win } = require('../window')
 const { groupedByTemplate } = require('../export')
 
 const {
+  getGroupedItems,
   getItemTemplate,
   getPhotoTemplate,
   getTemplateValues,
-  exportSelector,
 } = require('../selectors')
 
 
@@ -441,7 +441,7 @@ class Export extends Command {
 
       if (!target) return
 
-      const [templateItems, ...resources] = yield select(exportSelector(ids))
+      const [templateItems, ...resources] = yield select(getGroupedItems(ids))
 
       const results = yield call(groupedByTemplate, templateItems, resources)
       const asString = JSON.stringify(results, null, 2)

--- a/src/commands/item.js
+++ b/src/commands/item.js
@@ -24,7 +24,8 @@ const { groupedByTemplate } = require('../export')
 const {
   getItemTemplate,
   getPhotoTemplate,
-  getTemplateValues
+  getTemplateValues,
+  exportSelector,
 } = require('../selectors')
 
 
@@ -440,32 +441,7 @@ class Export extends Command {
 
       if (!target) return
 
-      const [templateItems, ...resources] = yield select(state => {
-        const itms = pick(state.items, ids)
-        const templateIDs = Object.values(itms).map(itm => itm.template)
-        const templates = pick(state.ontology.template, templateIDs)
-        let results = []
-
-        // check for missing templates
-        const isTrue = x => x === true
-        const hasTemplates = keys(state.ontology.template)
-        if (!templateIDs.map(t => hasTemplates.includes(t)).every(isTrue)) {
-          const notFound = templateIDs.filter(t => !hasTemplates.includes(t))[0]
-          throw new Error(`Template '${notFound}' not found.\n` +
-                          'Please create it though the preferences.')
-        }
-
-        for (const t in templates) {
-          const template = templates[t]
-          results.push({
-            template,
-            items: Object.values(itms).filter(i => i.template === t),
-          })
-        }
-        const needed = [
-          'metadata', 'photos', 'lists', 'tags', 'notes', 'selections']
-        return [results, state.ontology.props, ...pluck(state, needed)]
-      })
+      const [templateItems, ...resources] = yield select(exportSelector(ids))
 
       const results = yield call(groupedByTemplate, templateItems, resources)
       const asString = JSON.stringify(results, null, 2)

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -435,11 +435,10 @@ const util = {
     return true
   },
 
-  groupBy(xs, key, replacement = undefined) {
+  groupBy(xs, key) {
     return xs.reduce((res, x) => {
-      const val = x[key] || replacement
-      res[val] = res[val] || []
-      res[val].push(x)
+      res[x[key]] = res[x[key]] || []
+      res[x[key]].push(x)
       return res
     }, {})
   }

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -435,10 +435,11 @@ const util = {
     return true
   },
 
-  groupBy(xs, key) {
+  groupBy(xs, key, replacement = undefined) {
     return xs.reduce((res, x) => {
-      res[x[key]] = res[x[key]] || []
-      res[x[key]].push(x)
+      const val = x[key] || replacement
+      res[val] = res[val] || []
+      res[val].push(x)
       return res
     }, {})
   }

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -433,6 +433,14 @@ const util = {
     }
 
     return true
+  },
+
+  groupBy(xs, key) {
+    return xs.reduce((res, x) => {
+      res[x[key]] = res[x[key]] || []
+      res[x[key]].push(x)
+      return res
+    }, {})
   }
 }
 

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -435,11 +435,11 @@ const util = {
     return true
   },
 
-  groupBy(xs, key) {
-    return xs.reduce((res, x) => {
-      res[x[key]] = res[x[key]] || []
-      res[x[key]].push(x)
-      return res
+  groupBy(array, key) {
+    return array.reduce((acc, obj) => {
+      acc[obj[key]] = acc[obj[key]] || []
+      acc[obj[key]].push(obj)
+      return acc
     }, {})
   }
 }

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -6,9 +6,6 @@ const { pick, pluck } = require('../common/util')
 const { ITEM, PHOTO, SELECTION } = require('../constants/type')
 const makeNote = require('./note')
 
-const DUMMY_TEMPLATE = {
-  id: 'dummy'
-}
 const TR = 'https://tropy.org/v1/tropy#'
 
 const PROP = {
@@ -196,8 +193,8 @@ async function groupedByTemplate(templateItems, resources) {
   const results = []
   for (const templateID in templateItems) {
     const { items, template } = templateItems[templateID]
-    const context = makeContext(template || DUMMY_TEMPLATE, items, resources)
-    const document = makeDocument(template || DUMMY_TEMPLATE, items, resources)
+    const context = makeContext(template, items, resources)
+    const document = makeDocument(template, items, resources)
     document['@context'] = context
     results.push(await jsonld.compact(document, context))
   }

--- a/src/export/export.js
+++ b/src/export/export.js
@@ -6,6 +6,9 @@ const { pick, pluck } = require('../common/util')
 const { ITEM, PHOTO, SELECTION } = require('../constants/type')
 const makeNote = require('./note')
 
+const DUMMY_TEMPLATE = {
+  id: 'dummy'
+}
 const TR = 'https://tropy.org/v1/tropy#'
 
 const PROP = {
@@ -191,10 +194,10 @@ function makeDocument(template, items, resources) {
 
 async function groupedByTemplate(templateItems, resources) {
   const results = []
-  for (const ti of templateItems) {
-    const { template, items } = ti
-    const context = makeContext(template, items, resources)
-    const document = makeDocument(template, items, resources)
+  for (const templateID in templateItems) {
+    const { items, template } = templateItems[templateID]
+    const context = makeContext(template || DUMMY_TEMPLATE, items, resources)
+    const document = makeDocument(template || DUMMY_TEMPLATE, items, resources)
     document['@context'] = context
     results.push(await jsonld.compact(document, context))
   }

--- a/src/export/utils.js
+++ b/src/export/utils.js
@@ -7,7 +7,7 @@ const { entries, values } = Object
 function propertyLabel(property, props, template) {
   var label, field
   try {
-    if (template) {
+    if (template && template.fields) {
       field = template.fields.find(f => f.property === property)
       label = field && field.label
     }

--- a/src/selectors/export.js
+++ b/src/selectors/export.js
@@ -19,7 +19,7 @@ const exportSelector = (ids) => memo(
     return [
       entries(groupBy(values(items), 'template')).reduce((res, [t, items]) => {
         res[t] = {
-          template: templates[t],
+          template: templates[t] || { id: t },
           items
         }
         return res

--- a/src/selectors/export.js
+++ b/src/selectors/export.js
@@ -4,7 +4,7 @@ const { createSelector: memo } = require('reselect')
 const { pick, groupBy } = require('../common/util')
 const { values, entries } = Object
 
-const exportSelector = (ids) => memo(
+const getGroupedItems = (ids) => memo(
   ({ items }) => pick(items, ids),
   ({ ontology }) => ontology.props,
   ({ ontology }) => ontology.template,
@@ -36,5 +36,5 @@ const exportSelector = (ids) => memo(
 )
 
 module.exports = {
-  exportSelector
+  getGroupedItems
 }

--- a/src/selectors/export.js
+++ b/src/selectors/export.js
@@ -1,0 +1,40 @@
+'use strict'
+
+const { createSelector: memo } = require('reselect')
+const { pick, groupBy } = require('../common/util')
+const { values, entries } = Object
+
+const exportSelector = (ids) => memo(
+  ({ items }) => pick(items, ids),
+  ({ ontology }) => ontology.props,
+  ({ ontology }) => ontology.template,
+  ({ metadata }) => metadata,
+  ({ photos }) => photos,
+  ({ lists }) => lists,
+  ({ tags }) => tags,
+  ({ notes }) => notes,
+  ({ selections }) => selections,
+  (items, props, templates,
+   metadata, photos, lists, tags, notes, selections) => {
+    return [
+      entries(groupBy(values(items), 'template')).reduce((res, [t, items]) => {
+        res[t] = {
+          template: templates[t],
+          items
+        }
+        return res
+      }, {}),
+      props,
+      metadata,
+      photos,
+      lists,
+      tags,
+      notes,
+      selections
+    ]
+  }
+)
+
+module.exports = {
+  exportSelector
+}

--- a/src/selectors/index.js
+++ b/src/selectors/index.js
@@ -2,6 +2,7 @@
 
 module.exports = {
   ...require('./activity'),
+  ...require('./export'),
   ...require('./items'),
   ...require('./metadata'),
   ...require('./nav'),

--- a/test/common/util_test.js
+++ b/test/common/util_test.js
@@ -333,10 +333,5 @@ describe('util', () => {
       .to.eql({ undefined: [{ foo: 42 }] })
     expect(groupBy([{ foo: 42 }, { foo: 43 }], 'foo'))
       .to.eql({ 42: [{ foo: 42 }], 43: [{ foo: 43 }] })
-
-    it('replacement', () => {
-      expect(groupBy([{ foo: 42 }], 'bar', 'baz'))
-        .to.eql({ baz: [{ foo: 42 }] })
-    })
   })
 })

--- a/test/common/util_test.js
+++ b/test/common/util_test.js
@@ -333,5 +333,10 @@ describe('util', () => {
       .to.eql({ undefined: [{ foo: 42 }] })
     expect(groupBy([{ foo: 42 }, { foo: 43 }], 'foo'))
       .to.eql({ 42: [{ foo: 42 }], 43: [{ foo: 43 }] })
+
+    it('replacement', () => {
+      expect(groupBy([{ foo: 42 }], 'bar', 'baz'))
+        .to.eql({ baz: [{ foo: 42 }] })
+    })
   })
 })

--- a/test/common/util_test.js
+++ b/test/common/util_test.js
@@ -322,4 +322,16 @@ describe('util', () => {
     expect(camelcase('Foo Bar')).to.eql('fooBar')
     expect(camelcase('one two three')).to.eql('oneTwoThree')
   })
+
+  describe('.groupBy', () => {
+    const { groupBy } = util
+    expect(groupBy([])).to.eql({})
+    expect(groupBy([], 'foo')).to.eql({})
+    expect(groupBy([{ foo: 42 }], 'foo'))
+      .to.eql({ 42: [{ foo: 42 }] })
+    expect(groupBy([{ foo: 42 }], 'bar'))
+      .to.eql({ undefined: [{ foo: 42 }] })
+    expect(groupBy([{ foo: 42 }, { foo: 43 }], 'foo'))
+      .to.eql({ 42: [{ foo: 42 }], 43: [{ foo: 43 }] })
+  })
 })


### PR DESCRIPTION
This makes it possible to export items, whose template has been deleted. They are grouped under ~`dummy`~ their template ID.