### PR TITLE
Make visible selection notes when printing without metadata

### DIFF
--- a/src/components/print/photo.js
+++ b/src/components/print/photo.js
@@ -55,6 +55,10 @@ const Photo = ({ canOverflow, item, hasMetadata, hasNotes, photo, cache }) => {
                 heading="print.notes"/>}
           </div>
         </div>}
+      {!hasMetadata && hasNotes && !canOverflow &&
+        <NoteList
+          notes={photo.notes}
+          heading="print.notes"/>}
       {hasNotes && canOverflow &&
         <NoteList notes={photo.notes}/>}
     </div>

--- a/src/components/print/photo.js
+++ b/src/components/print/photo.js
@@ -34,31 +34,32 @@ const Photo = ({ canOverflow, item, hasMetadata, hasNotes, photo, cache }) => {
           className={`iiif rot-${rotation.format('x')}`}
           src={source(photo, cache)}/>
       </div>
-      {hasMetadata &&
+      {(hasMetadata || hasNotes) &&
         <div className={cx('metadata-container')}>
-          {item &&
-            <div className="col">
-              <MetadataSection
-                title="print.item"
-                fields={item.data}
-                tags={item.tags}/>
-              <ItemInfo item={item}/>
-            </div>}
           <div className="col">
-            <MetadataSection
-              title="print.photo"
-              fields={photo.data}/>
-            <PhotoInfo photo={photo}/>
+            {hasMetadata &&
+              <>
+                <MetadataSection
+                  title="print.item"
+                  fields={item.data}
+                  tags={item.tags}/>
+                <ItemInfo item={item}/>
+              </>}
+          </div>
+          <div className="col">
+            {hasMetadata &&
+              <>
+                <MetadataSection
+                  title="print.photo"
+                  fields={photo.data}/>
+                <PhotoInfo photo={photo}/>
+              </>}
             {hasNotes && !canOverflow &&
               <NoteList
                 notes={photo.notes}
                 heading="print.notes"/>}
           </div>
         </div>}
-      {!hasMetadata && hasNotes && !canOverflow &&
-        <NoteList
-          notes={photo.notes}
-          heading="print.notes"/>}
       {hasNotes && canOverflow &&
         <NoteList notes={photo.notes}/>}
     </div>


### PR DESCRIPTION
<img width="783" alt="Screen Shot 2019-10-15 at 3 01 46 PM" src="https://user-images.githubusercontent.com/655725/66861301-c1dc9800-ef5c-11e9-9641-ee885ef8b566.png">
