### PR TITLE
Use title bar style 'hidden' for frameless windows

### DIFF
--- a/scripts/rebuild.js
+++ b/scripts/rebuild.js
@@ -41,11 +41,15 @@ target.sqlite3 = async (force) => {
 
     if (!test('-f', tar)) {
       say(`${mod} fetching version ${version}...`)
-      let res = await fetch(url)
-      if (res.status !== 200)
-        throw new Error(`download failed: ${res.status} ${res.statusText}`)
+      if (process.platform === 'win32') {
+        let res = await fetch(url)
+        if (res.status !== 200)
+          throw new Error(`download failed: ${res.status} ${res.statusText}`)
 
-      write(tar, await res.buffer())
+        write(tar, await res.buffer())
+      } else {
+        exec(`curl -L ${url} > ${tar}`)
+      }
     }
 
     say(`${mod} patching...`)

--- a/scripts/rebuild.js
+++ b/scripts/rebuild.js
@@ -41,15 +41,11 @@ target.sqlite3 = async (force) => {
 
     if (!test('-f', tar)) {
       say(`${mod} fetching version ${version}...`)
-      if (process.platform === 'win32') {
-        let res = await fetch(url)
-        if (res.status !== 200)
-          throw new Error(`download failed: ${res.status} ${res.statusText}`)
+      let res = await fetch(url)
+      if (res.status !== 200)
+        throw new Error(`download failed: ${res.status} ${res.statusText}`)
 
-        write(tar, await res.buffer())
-      } else {
-        exec(`curl -L ${url} > ${tar}`)
-      }
+      write(tar, await res.buffer())
     }
 
     say(`${mod} patching...`)

--- a/src/browser/wm.js
+++ b/src/browser/wm.js
@@ -110,7 +110,11 @@ class WindowManager extends EventEmitter {
           if (!opts.frame && EL_CAPITAN) {
             opts.frame = true
             opts.title = ''
-            opts.titleBarStyle = opts.titleBarStyle || 'hiddenInset'
+            opts.titleBarStyle = opts.titleBarStyle || 'hidden'
+            opts.trafficLightPosition = {
+              x: 13,
+              y: 13
+            }
           }
           break
       }

--- a/src/browser/wm.js
+++ b/src/browser/wm.js
@@ -112,8 +112,8 @@ class WindowManager extends EventEmitter {
             opts.title = ''
             opts.titleBarStyle = opts.titleBarStyle || 'hidden'
             opts.trafficLightPosition = {
-              x: 13,
-              y: 13
+              x: 12,
+              y: 22
             }
           }
           break

--- a/src/browser/wm.js
+++ b/src/browser/wm.js
@@ -111,10 +111,7 @@ class WindowManager extends EventEmitter {
             opts.frame = true
             opts.title = ''
             opts.titleBarStyle = opts.titleBarStyle || 'hidden'
-            opts.trafficLightPosition = {
-              x: 12,
-              y: 22
-            }
+            opts.trafficLightPosition = getTrafficLightPosition(type)
           }
           break
       }
@@ -565,6 +562,15 @@ class WindowManager extends EventEmitter {
   }
 }
 
+
+const getTrafficLightPosition = (type) => {
+  switch (type) {
+    case 'prefs':
+      return { x: 12, y: 22 }
+    default:
+      return { x: 12, y: 22 }
+  }
+}
 
 const AQUA = { 1: 'blue', 6: 'graphite' }
 

--- a/src/browser/wm.js
+++ b/src/browser/wm.js
@@ -566,7 +566,7 @@ class WindowManager extends EventEmitter {
 const getTrafficLightPosition = (type) => {
   switch (type) {
     case 'prefs':
-      return { x: 12, y: 22 }
+      return { x: 7, y: 6 }
     default:
       return { x: 12, y: 22 }
   }

--- a/src/browser/wm.js
+++ b/src/browser/wm.js
@@ -421,10 +421,8 @@ class WindowManager extends EventEmitter {
     }).finally(() => { delete this.pending[id] })
   }
 
-  setTitle(type, title, frameless = false) {
-    if (!frameless) {
-      this.each(type, win => win.setTitle(title))
-    }
+  setTitle(type, title) {
+    this.each(type, win => win.setTitle(title))
   }
 
   async show(type, args, opts) {

--- a/src/browser/wm.js
+++ b/src/browser/wm.js
@@ -5,7 +5,7 @@ const { join } = require('path')
 const { URL } = require('url')
 const dialog = require('./dialog')
 const { debug, error, trace, warn } = require('../common/log')
-const { darwin, EL_CAPITAN } = require('../common/os')
+const { darwin } = require('../common/os')
 const { channel, paths } = require('../common/release')
 const res = require('../common/res')
 const { BODY, PANEL, ESPER } = require('../constants/sass')
@@ -107,7 +107,7 @@ class WindowManager extends EventEmitter {
           opts.darkTheme = opts.darkTheme || isDarkMode
           break
         case 'darwin':
-          if (!opts.frame && EL_CAPITAN) {
+          if (!opts.frame) {
             opts.frame = true
             opts.title = ''
             opts.titleBarStyle = opts.titleBarStyle || 'hidden'
@@ -422,7 +422,7 @@ class WindowManager extends EventEmitter {
   }
 
   setTitle(type, title, frameless = false) {
-    if (!frameless || !(darwin && EL_CAPITAN)) {
+    if (!frameless) {
       this.each(type, win => win.setTitle(title))
     }
   }

--- a/src/common/os.js
+++ b/src/common/os.js
@@ -6,10 +6,6 @@ const { qualified } = require('./release')
 const { SUPPORTED } = require('../constants/image')
 
 module.exports = {
-  get EL_CAPITAN() {
-    return platform === 'darwin' && os.release() > '15'
-  },
-
   get home() {
     return os.homedir()
   },

--- a/src/window.js
+++ b/src/window.js
@@ -3,7 +3,7 @@
 const { ipcRenderer: ipc } = require('electron')
 const { basename, join } = require('path')
 const { existsSync: exists } = require('fs')
-const { EL_CAPITAN, darwin } = require('./common/os')
+const { darwin } = require('./common/os')
 const { Plugins } = require('./common/plugins')
 const { delay, pick } = require('./common/util')
 const { paths } = require('./common/release')
@@ -89,10 +89,7 @@ class Window extends EventEmitter {
         if (frameless) {
           toggle(document.body, 'frameless', true)
 
-          if (EL_CAPITAN)
-            toggle(document.body, 'el-capitan', true)
-          else
-            this.createWindowControls()
+          if (!darwin) this.createWindowControls()
         }
 
         resolve()


### PR DESCRIPTION
- [x] Use titlebar style 'hidden'
- [x] Set appropriate traffic light position
- [ ] Check if we need different positions for High Sierra, Mojave, Catalina, Big Sur
- [x] Use different position per window (prefs!)
- [x] Remove empty window title hack
- [x] Remove old custom traffic lights / El Capitan hacks (closes #488)

See https://github.com/electron/electron/issues/14529
