### PR TITLE
Add format to date hint

### DIFF
--- a/res/ttp/generic.ttp
+++ b/res/ttp/generic.ttp
@@ -31,7 +31,7 @@
       "property": "http://purl.org/dc/elements/1.1/date",
       "label": null,
       "datatype": "https://tropy.org/v1/tropy#date",
-      "hint": "ISO format",
+      "hint": "ISO format (YYYY-MM-DD)",
       "isRequired": false,
       "isConstant": false,
       "value": null


### PR DESCRIPTION
This will be helpful for users until #381 is implemented. I found the format in https://docs.tropy.org/before-you-begin/metadata#date but it would be better to have it show up in the interface.

I have not compiled the project locally, so this may be the incorrect place to make this change. Apologies if so.

Thanks!