### PR TITLE
Add a "v" before version number in release url

### DIFF
--- a/res/strings/renderer.en.yml
+++ b/res/strings/renderer.en.yml
@@ -74,7 +74,7 @@ en:
         url: https://tropy.org/donate
       release:
         title: Release Notes
-        url: https://github.com/tropy/tropy/releases/tag/{version}
+        url: https://github.com/tropy/tropy/releases/tag/v{version}
       license:
         title: Licensing Information
         url: https://tropy.org/license


### PR DESCRIPTION
Fixes #653

The "v" was missing, I took a quick look at Transifex's docs and assume this will propagate so I only added it here.

Thank you for this very nice tool 😃
