### PR TITLE
Suggest tag to autocomplete after any kind of punctuation

### DIFF
--- a/src/components/tag/adder.js
+++ b/src/components/tag/adder.js
@@ -124,7 +124,7 @@ export class TagAdder extends React.PureComponent {
       match(
         value.name || String(value),
         query,
-        /(?<=[\s,.;:-]|^)(\d|\p{Alpha})/gmu)
+        /(?<=[\s\p{Punctuation}]|^)(\d|\p{Alpha})/gmu)
     ),
     separator: /\s*[;,]\s*/,
     onCancel: noop,

--- a/src/components/tag/adder.js
+++ b/src/components/tag/adder.js
@@ -16,13 +16,6 @@ import {
   string
 } from 'prop-types'
 
-export const matchFn = (value, query) => (
-  match(
-    value.name || String(value),
-    query,
-    /^.|(?<=[\s\p{Punctuation}])(\d|\p{Alpha})/gmu)
-)
-
 const TagAdderContainer = ({ children, count }) => {
   let intl = useIntl()
   let placeholder = intl.formatMessage({ id: 'panel.tags.add' }, { count })
@@ -126,7 +119,12 @@ export class TagAdder extends React.PureComponent {
   }
 
   static defaultProps = {
-    match: matchFn,
+    match: (value, query) => (
+      match(
+        value.name || String(value),
+        query,
+        /^.|(?<=[\s\p{Punctuation}])(\d|\p{Alpha})/gmu)
+    ),
     separator: /\s*[;,]\s*/,
     onCancel: noop,
     onFocus: noop

--- a/src/components/tag/adder.js
+++ b/src/components/tag/adder.js
@@ -16,6 +16,12 @@ import {
   string
 } from 'prop-types'
 
+export const matchFn = (value, query) => (
+  match(
+    value.name || String(value),
+    query,
+    /^.|(?<=[\s\p{Punctuation}])(\d|\p{Alpha})/gmu)
+)
 
 const TagAdderContainer = ({ children, count }) => {
   let intl = useIntl()
@@ -120,12 +126,7 @@ export class TagAdder extends React.PureComponent {
   }
 
   static defaultProps = {
-    match: (value, query) => (
-      match(
-        value.name || String(value),
-        query,
-        /(?<=[\s\p{Punctuation}]|^)(\d|\p{Alpha})/gmu)
-    ),
+    match: matchFn,
     separator: /\s*[;,]\s*/,
     onCancel: noop,
     onFocus: noop

--- a/test/components/tag/adder_test.js
+++ b/test/components/tag/adder_test.js
@@ -1,0 +1,70 @@
+describe('Tag autocomplete', () => {
+  const { matchFn } = __require('components/tag/adder')
+
+  it('Matches from the start of the tag', () => {
+    const tag = 'John Doe'
+    expect(matchFn(tag, 'Jo')).to.be.ok
+    expect(matchFn(tag, 'John')).to.be.ok
+    expect(matchFn(tag, 'John Do')).to.be.ok
+  })
+
+  it('Does not match sections from middle of words', () => {
+    const tag = 'John Doe'
+    expect(matchFn(tag, 'ohn')).not.to.be.ok
+    expect(matchFn(tag, 'oe')).not.to.be.ok
+    expect(matchFn(tag, 'n D')).not.to.be.ok
+  })
+
+  it('Matching is case-insensitive', () => {
+    const tag = 'John Doe'
+    expect(matchFn(tag, 'jo')).to.be.ok
+    expect(matchFn(tag, 'dO')).to.be.ok
+    expect(matchFn(tag, 'JOHN')).to.be.ok
+  })
+
+  it('Matches sections after any punctuation or whitespace', () => {
+    const query = 'Doe'
+    expect(matchFn('John Doe', query)).to.be.ok
+    expect(matchFn('John_Doe', query)).to.be.ok
+    expect(matchFn('John-Doe', query)).to.be.ok
+    expect(matchFn('John.Doe', query)).to.be.ok
+    expect(matchFn('John (Doe)', query)).to.be.ok
+    expect(matchFn('John(Doe)', query)).to.be.ok
+    expect(matchFn('John&Doe', query)).to.be.ok
+    expect(matchFn('John:Doe', query)).to.be.ok
+  })
+
+  it('Matches tags in non-latin scripts', () => {
+    const tag = 'այբուբենի ւ (վյուն)'
+    expect(matchFn(tag, 'այբո')).to.be.ok
+    expect(matchFn(tag, 'վյուն')).to.be.ok
+    expect(matchFn(tag, 'վյուն)')).to.be.ok
+    expect(matchFn(tag, 'այբուբենի ւ (վ')).to.be.ok
+  })
+
+  it('Matches tags that contain with emoji', () => {
+    const tag = '🚀 space 🌙'
+    expect(matchFn(tag, 'space')).to.be.ok
+    expect(matchFn(tag, '🚀')).to.be.ok
+    expect(matchFn(tag, 'space 🌙')).to.be.ok
+  })
+
+  it('Matches tags that start with punctuation', () => {
+    const tag = '!important'
+    expect(matchFn(tag, '!imp')).to.be.ok
+    expect(matchFn(tag, 'imp')).to.be.ok
+  })
+
+  it('Matches tags that contain punctuation', () => {
+    const tag = 'John (Joe, Johnny) Doe'
+    expect(matchFn(tag, 'Joe')).to.be.ok
+    expect(matchFn(tag, 'John (Joe')).to.be.ok
+    expect(matchFn(tag, 'Joe, Johnny)')).to.be.ok
+  })
+
+  it('Does not match punctuation typed at the start of a query mid-tag', () => {
+    const tag = 'John (Joe, Johnny) Doe'
+    expect(matchFn(tag, ') Doe')).not.to.be.ok
+    expect(matchFn(tag, '(Joe')).not.to.be.ok
+  })
+})

--- a/test/components/tag/adder_test.js
+++ b/test/components/tag/adder_test.js
@@ -1,5 +1,6 @@
+import { TagAdder } from '../../../src/components/tag/adder'
+
 describe('Tag autocomplete', () => {
-  const { TagAdder } = __require('components/tag/adder')
   const matchFn = TagAdder.defaultProps.match
   it('Matches from the start of the tag', () => {
     const tag = 'John Doe'

--- a/test/components/tag/adder_test.js
+++ b/test/components/tag/adder_test.js
@@ -1,6 +1,6 @@
 describe('Tag autocomplete', () => {
-  const { matchFn } = __require('components/tag/adder')
-
+  const { TagAdder } = __require('components/tag/adder')
+  const matchFn = TagAdder.defaultProps.match
   it('Matches from the start of the tag', () => {
     const tag = 'John Doe'
     expect(matchFn(tag, 'Jo')).to.be.ok


### PR DESCRIPTION
closes #665. Treat any kind of punctuation as a "word boundary" to start matching for autocomplete