### PR TITLE
Fix and reinstantiate AppImage builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -128,7 +128,8 @@ jobs:
           allowUpdates: true
           artifacts: >-
             dist/*.bz2,
-            dist/*.integrity
+            dist/*.integrity,
+            dist/*.AppImage
           omitBodyDuringUpdate: true
           omitNameDuringUpdate: true
           prerelease: true

--- a/scripts/build.js
+++ b/scripts/build.js
@@ -358,6 +358,7 @@ Version=1.0
 Terminal=false
 Type=Application
 Name=${qualified.product}
+Comment=Research photo management
 Exec=${exe} %U
 Icon=${icon}
 MimeType=${mimetypes.join(';')};

--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -136,13 +136,13 @@ const exports = {
     mv(`${AppDir}/resources/icons`, `${AppDir}/usr/share/icons`)
     mv(`${AppDir}/resources/mime`, `${AppDir}/usr/share/mime`)
 
-    let png = `usr/share/icons/hicolor/512x512/apps/${qualified.name}.png`
-    let svg = `usr/share/icons/hicolor/scalable/apps/${qualified.name}.svg`
+    let png = `usr/share/icons/hicolor/512x512/apps/${qualified.appId}.png`
+    let svg = `usr/share/icons/hicolor/scalable/apps/${qualified.appId}.svg`
 
     cd(AppDir)
     ln('-s', qualified.name, 'AppRun')
     ln('-s', png, '.DirIcon')
-    ln('-s', svg, `${qualified.name}.svg`)
+    ln('-s', svg, `${qualified.appId}.svg`)
     cd('-')
 
     exec(`"${appimagetool}" -n -v ${AppDir} ${output}`, { silent })

--- a/scripts/pack.js
+++ b/scripts/pack.js
@@ -76,7 +76,7 @@ program
       if (!args.length) {
         args = ({
           darwin: ['dmg', '7z'],
-          linux: ['bz2'],
+          linux: ['bz2', 'AppImage'],
           win32: ['squirrel']
         })[opts.platform]
       }


### PR DESCRIPTION
AppImage builds were failing because in some places in the relevant function in `scripts/pack.js`, `qualified.main` was used where `qualified.appId` gives the correct identifier.

Including that, this PR does three changes:

- Revert the commit that disables AppImage builds
- Use `qualified.appId` where necessary
- Fill in the `Comment=` field in the `.desktop` file

The last change is not necessary for the AppImage to build, but `appimagetool` does complain if the field is absent. It is a standard and required field anyways, I believe, and it shows up in application menus and runner tools as the description of the application. I used the description of the repository on Github to fill in the field.

(Relatedly, another warning that the `.desktop` file generates is about the `Categories=` field, because it lists multiple toplevel categories, meaning it would show up in multiple toplevel menus in supporting launchers. I did not touch the categories because I don't know which one would make sense to remove. The warning is non-fatal, `appimagetool` reports it as a "hint".)

Tests pass on my machine. I was not able to run Github workflows on my fork, but I reckon they'll run when I submit this PR.

Fixes #875