### PR TITLE
Add RAW image support

### DIFF
--- a/src/asset/magic.js
+++ b/src/asset/magic.js
@@ -1,14 +1,15 @@
 import MIME from '../constants/mime.js'
+import IMAGE from '../constants/image.js'
 
 
 export function magic (buffer, ext = '') {
+  let raw = isRAW(ext)
+
   if (buffer != null) {
     if (isJPEG(buffer))
       return MIME.JPEG
     if (isPNG(buffer))
       return MIME.PNG
-    if (isTIFF(buffer))
-      return MIME.TIFF
     if (isPDF(buffer))
       return MIME.PDF
     if (isGIF(buffer))
@@ -27,7 +28,14 @@ export function magic (buffer, ext = '') {
       return MIME.EPS
     if (isPS(buffer))
       return MIME.PS
+    if (raw)
+      return MIME.RAW
+    if (isTIFF(buffer))
+      return MIME.TIFF
   }
+
+  if (raw)
+    return MIME.RAW
 }
 
 const isGIF = (buffer) =>
@@ -58,6 +66,9 @@ const isPS = (buffer) =>
 
 const isEPS = (buffer) =>
   buffer.toString('ascii', 0, 23) === '%!PS-Adobe-3.0 EPSF-3.0'
+
+const isRAW = (ext) =>
+  IMAGE.RAW.EXT.includes(ext.toLowerCase().replace(/^\./, ''))
 
 const isTIFF = (buffer) =>
   check(buffer, [0x49, 0x49, 42, 0]) || check(buffer, [0x4d, 0x4d, 0, 42])

--- a/src/commands/photo/extract.js
+++ b/src/commands/photo/extract.js
@@ -110,6 +110,7 @@ function getSuggestedFilename (state, props) {
     case MIME.JP2:
     case MIME.J2K:
     case MIME.JPX:
+    case MIME.RAW:
       return `${name}.jpg`
     default:
       return `${name}.jpg`

--- a/src/constants/image.js
+++ b/src/constants/image.js
@@ -1,5 +1,54 @@
 import MIME from './mime.js'
 
+const RAW = {
+  EXT: [
+    '3fr',
+    'ari',
+    'arw',
+    'bay',
+    'bmq',
+    'cap',
+    'cine',
+    'cr2',
+    'cr3',
+    'crw',
+    'cs1',
+    'dc2',
+    'dcr',
+    'dng',
+    'erf',
+    'fff',
+    'gpr',
+    'iiq',
+    'k25',
+    'kc2',
+    'kdc',
+    'mdc',
+    'mef',
+    'mos',
+    'mrw',
+    'nef',
+    'nrw',
+    'orf',
+    'pef',
+    'pxn',
+    'qtk',
+    'raf',
+    'raw',
+    'rdc',
+    'rw1',
+    'rw2',
+    'rwl',
+    'rwz',
+    'sr2',
+    'srf',
+    'srw',
+    'sti',
+    'x3f'
+  ],
+  MIN_VIPS: '8.18.0'
+}
+
 const SUPPORTED = {
   [MIME.AVIF]: true,
   [MIME.AVIF_SEQ]: true,
@@ -16,6 +65,7 @@ const SUPPORTED = {
   [MIME.PNG]: true,
   [MIME.PDF]: true,
   [MIME.PS]: true,
+  [MIME.RAW]: true,
   [MIME.SVG]: true,
   [MIME.TIFF]: true,
   [MIME.WEBP]: true
@@ -41,6 +91,7 @@ export default {
     'pdf',
     'png',
     'ps',
+    ...RAW.EXT,
     'svg',
     'tif',
     'tiff',
@@ -62,6 +113,8 @@ export default {
     [MIME.PS]: true,
     [MIME.SVG]: true
   },
+
+  RAW,
 
   SUPPORTED
 }

--- a/src/constants/mime.js
+++ b/src/constants/mime.js
@@ -19,6 +19,7 @@ export default {
   PDF: 'application/pdf',
   PNG: 'image/png',
   PS: 'application/postscript',
+  RAW: 'image/x-dcraw',
   SVG: 'image/svg+xml',
   TIF: 'image/tiff',
   TIFF: 'image/tiff',

--- a/src/image/image.js
+++ b/src/image/image.js
@@ -1,5 +1,6 @@
 import { createHash } from 'node:crypto'
 import { rdjpgcom } from 'rdjpgcom'
+import lt from 'semver/functions/lt.js'
 import { Asset } from '../asset/index.js'
 import { exif } from './exif.js'
 import { xmp } from './xmp.js'
@@ -21,7 +22,9 @@ export class Image extends Asset {
         return 1
       default:
         return Orientation(
-          this.meta?.[this.page]?.exif?.[exifns.orientation]?.text || 1
+          this.meta?.[this.page]?.exif?.[exifns.orientation]?.text ||
+          this.meta?.[this.page]?.orientation ||
+          1
         )
     }
   }
@@ -81,7 +84,11 @@ export class Image extends Asset {
   }
 
   do (page = this.page, autoOrient = false) {
-    return sharp(this.original?.buffer || this.buffer || this.path, {
+    let input = (this.mimetype === MIME.RAW && !this.isRemote) ?
+      this.path :
+      this.original?.buffer || this.buffer || this.path
+
+    return sharp(input, {
       autoOrient,
       page,
       density: this.density
@@ -217,10 +224,19 @@ export class Image extends Asset {
   }
 
   async parse ({ page, density = 72, useLocalTimezone }) {
-    await init()
+    let vip = await init()
 
     if (!IMAGE.SUPPORTED[this.mimetype])
       throw new Error(`image type not supported: ${this.mimetype}`)
+
+    if (
+      this.mimetype === MIME.RAW &&
+      lt(vip.versions.vips, IMAGE.RAW.MIN_VIPS)
+    ) {
+      throw new Error(
+        `image type requires libvips ${IMAGE.RAW.MIN_VIPS} or later: ${this.mimetype}`
+      )
+    }
 
     if (IMAGE.SCALABLE[this.mimetype])
       this.density = restrict(density, IMAGE.MIN_DENSITY, IMAGE.MAX_DENSITY)

--- a/test/asset/magic.test.js
+++ b/test/asset/magic.test.js
@@ -1,0 +1,24 @@
+import { magic } from '#tropy/asset/magic.js'
+import { IMAGE, MIME } from '#tropy/constants/index.js'
+
+describe('asset magic', () => {
+  it('detects raw camera files by extension', () => {
+    for (let ext of IMAGE.RAW.EXT) {
+      expect(magic(Buffer.alloc(0), `.${ext}`)).to.equal(MIME.RAW)
+    }
+  })
+
+  it('prefers raw camera extensions over TIFF magic', () => {
+    let tiff = Buffer.from([0x49, 0x49, 42, 0])
+
+    expect(magic(tiff, '.CR2')).to.equal(MIME.RAW)
+  })
+
+  it('keeps strong magic numbers ahead of raw camera extensions', () => {
+    let jpeg = Buffer.from([0xFF, 0xD8, 0xFF])
+    let pdf = Buffer.from([0x25, 0x50, 0x44, 0x46])
+
+    expect(magic(jpeg, '.CR2')).to.equal(MIME.JPEG)
+    expect(magic(pdf, '.CR2')).to.equal(MIME.PDF)
+  })
+})


### PR DESCRIPTION
Add RAW image support, see https://github.com/tropy/tropy/issues/934.

- Add RAW camera file extensions and a generic RAW MIME type.
- Detect TIFF-based camera RAW files by extension.
- Load local RAW files through sharp/libvips (requires 8.18.x).
- Export RAW-derived images as JPEG.

Depends on the following changes:
- tropy/build-win64-mxe#1
- tropy/sharp-libvips#1

Consider this a draft since it requires the above changes.