### PR TITLE
Fix typo in API transcription create endpoint

### DIFF
--- a/src/common/api.js
+++ b/src/common/api.js
@@ -184,7 +184,7 @@ const project = {
       assert.ok(photo || selection, 400,
         'missing photo or selection parameter')
 
-      let { payload } = await rsvp('project', act.transcriptions.create({
+      let { payload } = await rsvp('project', act.transcription.create({
         data,
         text,
         angle,


### PR DESCRIPTION
## Summary

`POST /project/transcriptions` currently always returns **500 Internal Server Error** because of a one-character action-name typo in the API handler.

```
TypeError: Cannot read properties of undefined (reading 'create')
    at create (.../src/common/api.js:187)
```

`src/common/api.js:187` calls `act.transcriptions.create(...)` (plural), but `src/actions/api.js` only exports `transcription` (singular). `act.transcriptions` is therefore `undefined`, so accessing `.create` throws.

For comparison, every other call site uses the singular form:

- `src/common/api.js:216` — `act.transcription.find(...)`
- `src/common/api.js:244` — `act.transcription.show(...)`

## Fix

```diff
- let { payload } = await rsvp('project', act.transcriptions.create({
+ let { payload } = await rsvp('project', act.transcription.create({
```

## Reproduction (before this PR)

Start Tropy with the API enabled and a project open:

```bash
npm start -- --port 2019 /path/to/some.tropy
```

then:

```bash
curl -X POST 'http://127.0.0.1:2019/project/transcriptions' \
  -d 'photo=<some-photo-id>' \
  -d 'text=hello'
# → HTTP/1.1 500 Internal Server Error
#   tmp/log/tropy.log shows:
#   TypeError: Cannot read properties of undefined (reading 'create')
```

## Verification (after this PR)

Same request now returns 200 with the new transcription id, and the row persists in the project DB:

```bash
$ curl -X POST 'http://127.0.0.1:2019/project/transcriptions' \
    -d 'photo=8' -d 'text=hello'
{"id":[7]}

$ sqlite3 /path/to/project.tpy "SELECT transcription_id, id, text FROM transcriptions WHERE transcription_id = 7;"
7|8|hello
```

## Follow-up

There is a separate issue that will be filed separately: after a successful `POST /project/transcriptions`, an immediate `GET /project/transcriptions/:id` returns 404 because `TranscriptionCreate` writes the row to the DB but does not dispatch a Redux action to update `state.transcriptions` (compare with `NoteCreate` in `src/commands/api/note.js`, which dispatches `act.photo.notes.add` / `act.note.select`). After a project reload the row is visible. That fix is more invasive than this typo and benefits from maintainer input on the preferred dispatch shape, so it's intentionally out of scope here.

## Test

- Tested against `main` HEAD (11a086d70 "Ignore react server directives / warnings").
- No new tests added; if you'd like a spec for the API transcription create path I'm happy to follow up.