### PR TITLE
Update state when creating transcriptions via API

### DIFF
--- a/src/commands/api/transcription.js
+++ b/src/commands/api/transcription.js
@@ -1,4 +1,4 @@
-import { call, select } from 'redux-saga/effects'
+import { call, put, select } from 'redux-saga/effects'
 import { Command } from '../command.js'
 import { Document } from 'alto-xml'
 import { API } from '../../constants/index.js'
@@ -13,7 +13,7 @@ export class TranscriptionCreate extends Command {
     let { db } = this.options
     let { data, text, angle, mirror, photo, selection } = this.action.payload
 
-    if (photo == null) {
+    if (photo == null && selection == null) {
       ({ photo, selection } = yield select(state => state.nav))
     }
 
@@ -27,6 +27,8 @@ export class TranscriptionCreate extends Command {
     let transcriptions = yield call(db.transaction, async tx =>
       Promise.all(parents.map(parent =>
         create(tx, { angle, mirror, data, parent, text }))))
+
+    yield put(slice.insert(transcriptions))
 
     this.undo = slice.remove(
       transcriptions.map(tr => tr.id))

--- a/src/reducers/photos.js
+++ b/src/reducers/photos.js
@@ -34,6 +34,8 @@ export function photos (state = {}, { type, payload, error, meta }) {
 
     case tr.create.type:
       return tr.nested.create(state, { payload, meta, error })
+    case tr.insert.type:
+      return tr.nested.insert(state, { payload })
     case tr.remove.type:
       return tr.nested.remove(state, { payload, meta, error })
     case tr.restore.type:

--- a/src/reducers/selections.js
+++ b/src/reducers/selections.js
@@ -34,6 +34,8 @@ export function selections (state = init, { type, payload, error, meta }) {
 
     case tr.create.type:
       return tr.nested.create(state, { payload, meta, error })
+    case tr.insert.type:
+      return tr.nested.insert(state, { payload })
     case tr.remove.type:
       return tr.nested.remove(state, { payload, meta, error })
     case tr.restore.type:

--- a/src/slices/transcriptions.js
+++ b/src/slices/transcriptions.js
@@ -56,6 +56,18 @@ export const nested = {
       })
   },
 
+  insert (state, { payload }) {
+    return createNextState(state, draft => {
+      for (let tr of payload) {
+        let parent = draft[tr.parent]
+
+        if (parent != null && !parent.transcriptions.includes(tr.id))
+          parent.transcriptions.push(tr.id)
+      }
+      return draft
+    })
+  },
+
   remove (state, { payload, meta, error }) {
     return (!meta.done || error) ?
       state : createNextState(state, draft => {


### PR DESCRIPTION
Transcriptions created via the API were written to the database, but never dispatched into the store: they stayed invisible until the project was re-opened, and undo threw because `getTranscriptionsForRemoval` could not find them in state.

* Dispatch `transcriptions/insert` after the transaction
* Add a nested `insert` handler (mirroring `nested.create`) so the ids are attached to their parent photo/selection; it skips ids the parent already holds, so the import and duplicate paths cannot double-add
* Fall back to the current nav photo/selection only if neither was given -- a `selection=` POST used to be redirected to whatever photo the window was showing

Not reusing `create` with `meta.done` on purpose: `onTranscriptionAdded` would submit a transcription job for any `status === 0` result.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
