### PR TITLE
Add explode, merge, and nav routes to the API

### DIFF
--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -75,6 +75,19 @@ export default {
     }
   },
 
+  nav: {
+    show (payload, meta) {
+      return {
+        type: API.NAV.SHOW,
+        payload,
+        meta: {
+          cmd: 'project',
+          ...meta
+        }
+      }
+    }
+  },
+
   metadata: {
     save ({ id, ...payload }, meta) {
       return {

--- a/src/actions/api.js
+++ b/src/actions/api.js
@@ -20,6 +20,35 @@ export default {
   },
 
   item: {
+    explode ({ id, photos }, meta) {
+      return {
+        type: ITEM.EXPLODE,
+        payload: {
+          id: Number(id),
+          photos: array(photos).map(Number)
+        },
+        meta: {
+          cmd: 'project',
+          history: 'add',
+          search: true,
+          ...meta
+        }
+      }
+    },
+
+    merge (payload, meta) {
+      return {
+        type: ITEM.MERGE,
+        payload: array(payload).map(Number),
+        meta: {
+          cmd: 'project',
+          history: 'add',
+          search: true,
+          ...meta
+        }
+      }
+    },
+
     find ({ tags, ...payload }, meta) {
       return {
         type: API.ITEM.FIND,

--- a/src/commands/api/index.js
+++ b/src/commands/api/index.js
@@ -1,6 +1,7 @@
 export * from './item.js'
 export * from './list.js'
 export * from './metadata.js'
+export * from './nav.js'
 export * from './note.js'
 export * from './photo.js'
 export * from './selection.js'

--- a/src/commands/api/nav.js
+++ b/src/commands/api/nav.js
@@ -1,0 +1,16 @@
+import { select } from 'redux-saga/effects'
+import { Command } from '../command.js'
+import { API } from '../../constants/index.js'
+import { pick } from '../../common/util.js'
+
+const PROPS = [
+  'items', 'photo', 'selection', 'note', 'list', 'mode', 'query', 'tags'
+]
+
+export class NavShow extends Command {
+  *exec () {
+    return yield select(state => pick(state.nav, PROPS))
+  }
+}
+
+NavShow.register(API.NAV.SHOW)

--- a/src/commands/item/explode.js
+++ b/src/commands/item/explode.js
@@ -22,6 +22,12 @@ export class Explode extends Command {
     let moves = {}
 
     if (payload.items == null) {
+      // Photos are moved onto duplicates of their own item, so a photo
+      // that belongs elsewhere would be detached from its item silently.
+      assert(
+        photos.every(id => item.photos.includes(id)),
+        'photos must belong to the item')
+
       yield call(db.transaction, async tx => {
         for (let photo of photos) {
           let dup = await mod.item.dup(tx, item.id)

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -115,6 +115,16 @@ const project = {
     show: show('item')
   },
 
+  nav: {
+    async show (ctx) {
+      let { rsvp } = ctx
+
+      let { payload } = await rsvp(act.nav.show({}))
+
+      ctx.body = payload
+    }
+  },
+
   data: {
     async save (ctx) {
       let { assert, params, request, rsvp } = ctx
@@ -505,6 +515,8 @@ export function create ({
     .delete('/project/:project/items/:id/tags', project.tags.remove)
     .post('/project/:project/items/merge', project.items.merge)
     .post('/project/:project/items/:id/explode', project.items.explode)
+
+    .get('/project/:project/nav', project.nav.show)
 
     .get('/project/:project/lists/:id/items', project.items.find)
     .get('/project/:project/lists{/:id}', project.lists.show)

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -5,6 +5,11 @@ import Router from '@koa/router'
 import bodyParser from 'koa-bodyparser'
 import act from '../actions/api'
 
+// Beyond qs's arrayLimit, repeated parameters are parsed into an object
+// keyed by index instead of an array, which quietly breaks every route
+// taking a list: an item's photos, the items to merge, an item's tags.
+const ARRAY_LIMIT = 1000
+
 const show = (type) =>
   async (ctx) => {
     let { params, rsvp } = ctx
@@ -566,7 +571,7 @@ export function create ({
 
   app
     .use(logging)
-    .use(bodyParser())
+    .use(bodyParser({ queryString: { arrayLimit: ARRAY_LIMIT } }))
     .use(api.routes())
     .use(api.allowedMethods())
 

--- a/src/common/api.js
+++ b/src/common/api.js
@@ -71,6 +71,33 @@ const project = {
   },
 
   items: {
+    async explode (ctx) {
+      let { assert, params, request, rsvp } = ctx
+      let { photo } = request.body
+
+      assert.ok(photo, 400, 'missing photo parameter')
+
+      let { payload } = await rsvp(act.item.explode({
+        id: params.id,
+        photos: photo
+      }))
+
+      ctx.body = {
+        item: Object.values(payload).map(({ id, photos }) => ({ id, photos }))
+      }
+    },
+
+    async merge (ctx) {
+      let { assert, request, rsvp } = ctx
+      let { item } = request.body
+
+      assert.ok(item, 400, 'missing item parameter')
+
+      let { payload } = await rsvp(act.item.merge(item))
+
+      ctx.body = payload
+    },
+
     async find (ctx) {
       let { params, query, rsvp } = ctx
       let { sort = 'item.created', reverse = false } = query
@@ -476,6 +503,8 @@ export function create ({
       project.transcriptions.find)
     .post('/project/:project/items/:id/tags', project.tags.add)
     .delete('/project/:project/items/:id/tags', project.tags.remove)
+    .post('/project/:project/items/merge', project.items.merge)
+    .post('/project/:project/items/:id/explode', project.items.explode)
 
     .get('/project/:project/lists/:id/items', project.items.find)
     .get('/project/:project/lists{/:id}', project.lists.show)

--- a/src/constants/api.js
+++ b/src/constants/api.js
@@ -4,6 +4,10 @@ export default {
     SHOW: 'api.item.show'
   },
 
+  NAV: {
+    SHOW: 'api.nav.show'
+  },
+
   PHOTO: {
     EXTRACT: 'api.photo.extract',
     FIND: 'api.photo.find',


### PR DESCRIPTION
The API can read items and photos and create them via import, but there is no
way to move a photo to a different item, so it cannot reorganise a project.

- `POST /project/:project/items/:id/explode` — moves each `photo` onto a
  duplicate of the item, returns `{ item: [{ id, photos }] }`
- `POST /project/:project/items/merge` — merges the given `item` ids into the
  first, returns the merged item
- `GET /project/:project/nav` — the current selection: items, photo, selection,
  note, list, mode, query, tags

The write routes dispatch the existing `Explode` and `Merge` commands, so they
behave exactly as the UI does and register undo/redo.

Two things worth a look:

- `Explode` now asserts that the photos belong to the item. Over HTTP a stray
  id would otherwise be moved onto a duplicate of the wrong parent and silently
  detached from its own item. The assert is in the fresh-explode branch only,
  so undo/redo is unaffected — but it does mean a bad request fails as a
  command error rather than a 400.
- The nav commit is separable. Drop it if what the API should expose of the
  current selection needs more thought; the write routes don't depend on it.
