### PR TITLE
Fix/api urls

### DIFF
--- a/src/common/api.js
+++ b/src/common/api.js
@@ -1,9 +1,9 @@
-import fs from 'fs'
-import { basename } from 'path'
+import fs from 'node:fs'
+import { basename } from 'node:path'
 import Koa from 'koa'
 import Router from '@koa/router'
 import bodyParser from 'koa-bodyparser'
-import act from '../actions/api'
+import act from '../actions/api.js'
 
 const show = (type) =>
   async (ctx) => {
@@ -505,7 +505,7 @@ export function create ({
 
     .get('/project/:project{/}', (ctx) => {
       ctx.body = {
-        project: ctx.projectPath || ctx.current(),
+        project: ctx.projectPath,
         id: ctx.projectId,
         status: 'ok',
         version

--- a/src/main/api.js
+++ b/src/main/api.js
@@ -38,9 +38,12 @@ export class Server {
       return { win, path, id: urlId(path) }
     }
 
+    // mimic urlId() treatment
+    let encoded = encodeURIComponent(id.toWellFormed().normalize())
+
     // Several projects can share a URL id when their files have the same
     // basename; resolve to the most recent.
-    let matches = this.app.state.recent.filter(f => urlId(f) === id)
+    let matches = this.app.state.recent.filter(f => urlId(f) === encoded)
 
     if (matches.length === 0)
       throw new HttpError({ status: 404, body: `unknown project: ${id}` })
@@ -56,7 +59,7 @@ export class Server {
     return {
       win,
       path,
-      id,
+      id: encoded,
       ambiguous: matches.length > 1
     }
   }

--- a/test/common/api.test.js
+++ b/test/common/api.test.js
@@ -1,0 +1,112 @@
+import { once } from 'node:events'
+import { HttpError } from '#tropy/common/error.js'
+import * as api from '#tropy/common/api.js'
+
+describe('api', () => {
+  let server, url, rsvp, resolveProject
+
+  const context = () => ({
+    current: () => '/tmp/current.tpy',
+    dispatch: () => {},
+    log: { debug () {}, error () {} },
+    resolveProject: (id) => resolveProject(id),
+    rsvp: (win, action) => rsvp(action),
+    version: '1.0.0'
+  })
+
+  beforeEach(async () => {
+    rsvp = async () => ({ payload: null })
+    resolveProject = (id) => ({ win: {}, path: `/tmp/${id}.tpy`, id })
+
+    server = api.create(context()).listen(0)
+    await once(server, 'listening')
+
+    url = `http://127.0.0.1:${server.address().port}`
+  })
+
+  afterEach(async () => {
+    server.closeAllConnections()
+    server.close()
+    await once(server, 'close')
+  })
+
+  describe('GET /version', () => {
+    it('returns the version', async () => {
+      let res = await fetch(`${url}/version`)
+
+      expect(res.status).to.equal(200)
+      expect(await res.json()).to.eql({ version: '1.0.0' })
+    })
+  })
+
+  describe('GET /', () => {
+    it('returns the current project', async () => {
+      let res = await fetch(`${url}/`)
+
+      expect(res.status).to.equal(200)
+      expect(await res.json()).to.eql({
+        project: '/tmp/current.tpy',
+        status: 'ok',
+        version: '1.0.0'
+      })
+    })
+  })
+
+  describe('GET /project/:project', () => {
+    it('returns the resolved project', async () => {
+      let res = await fetch(`${url}/project/foo`)
+
+      expect(res.status).to.equal(200)
+      expect(await res.json()).to.eql({
+        project: '/tmp/foo.tpy',
+        id: 'foo',
+        status: 'ok',
+        version: '1.0.0'
+      })
+    })
+
+    it('warns when the project url is ambiguous', async () => {
+      resolveProject = (id) => ({
+        win: {}, path: `/tmp/a/${id}.tpy`, id, ambiguous: true
+      })
+
+      let res = await fetch(`${url}/project/foo`)
+
+      expect(res.status).to.equal(200)
+      expect(res.headers.get('warning')).to.match(/^199 - "ambiguous/)
+    })
+
+    it('returns 404 if the project cannot be resolved', async () => {
+      resolveProject = () => {
+        throw new HttpError({ status: 404, body: 'unknown project: foo' })
+      }
+
+      let res = await fetch(`${url}/project/foo`)
+
+      expect(res.status).to.equal(404)
+    })
+  })
+
+  describe('GET /project/:project/items/:id', () => {
+    it('returns the payload and the requested id', async () => {
+      let action
+
+      rsvp = async (a) => {
+        action = a
+        return { payload: { id: 42, title: 'Test' } }
+      }
+
+      let res = await fetch(`${url}/project/foo/items/42`)
+
+      expect(res.status).to.equal(200)
+      expect(await res.json()).to.have.property('title', 'Test')
+      expect(action).to.have.nested.property('payload.id', '42')
+    })
+
+    it('returns 404 when the item is missing', async () => {
+      let res = await fetch(`${url}/project/foo/items/42`)
+
+      expect(res.status).to.equal(404)
+    })
+  })
+})

--- a/test/common/util.test.js
+++ b/test/common/util.test.js
@@ -644,9 +644,7 @@ describe('util', () => {
       expect(fn.mock.calls[1].arguments).to.eql(['b'])
     })
   })
-})
 
-describe('url', () => {
   describe('urlId', () => {
     it('derives the id from the file basename', () => {
       expect(util.urlId('/path/to/My Project.tpy')).to.equal('My%20Project')

--- a/test/main/api.test.js
+++ b/test/main/api.test.js
@@ -1,0 +1,34 @@
+import { Server } from '#tropy/main/api.js'
+
+describe('api.Server', () => {
+  describe('resolveProject', () => {
+    let win = {}
+    let server = new Server({
+      state: { recent: ['/x/Cartografia Histórica.tpy', '/x/foo.tpy'] },
+      wm: { current: () => win, values: () => [win] },
+      getProject: () => ({ path: '/x/Cartografia Histórica.tpy' }),
+      opts: {}
+    })
+
+    it('matches decoded ids against encoded urlIds', () => {
+      // the router decodes path params before they reach resolveProject
+      let { path, id } = server.resolveProject('Cartografia Histórica')
+
+      expect(path).to.equal('/x/Cartografia Histórica.tpy')
+      expect(id).to.equal('Cartografia%20Hist%C3%B3rica')
+    })
+
+    it('resolves "current" to the focused project window', () => {
+      let { path, id } = server.resolveProject('current')
+
+      expect(path).to.equal('/x/Cartografia Histórica.tpy')
+      expect(id).to.equal('Cartografia%20Hist%C3%B3rica')
+    })
+
+    it('throws 404 for unknown projects', () => {
+      expect(() => server.resolveProject('nope'))
+        .to.throw()
+        .with.property('status', 404)
+    })
+  })
+})


### PR DESCRIPTION
Fixes a bug where API routes wouldn't match the encoded project id and adds minimal API tests.